### PR TITLE
Bump Log::Any minimum version from 0 to 0.15

### DIFF
--- a/lib/Search/Elasticsearch/Logger/LogAny.pm
+++ b/lib/Search/Elasticsearch/Logger/LogAny.pm
@@ -5,7 +5,7 @@ with 'Search::Elasticsearch::Role::Logger';
 use Search::Elasticsearch::Util qw(parse_params to_list);
 use namespace::clean;
 
-use Log::Any();
+use Log::Any() 0.15;
 use Log::Any::Adapter();
 
 #===================================


### PR DESCRIPTION
Today I was working on a repo with an older version of Log::Any
installed, but no Log::Any::Adapter.  I was unable to get
Log::Any::Adapter installed until I bumped Log::Any from 0.14 to 0.15 on
my end.  So, I think bumping the version makes sense.  Since it actually
has no deps, this shouldn't be a blocker to anyone upgrading.
