### PR TITLE
Add support for ssl_options when talking to https nodes.

### DIFF
--- a/lib/Search/Elasticsearch/Cxn/HTTPTiny.pm
+++ b/lib/Search/Elasticsearch/Cxn/HTTPTiny.pm
@@ -60,8 +60,12 @@ sub _build_handle {
     my %args = ( default_headers => $self->default_headers );
     if ( $self->is_https ) {
         require IO::Socket::SSL;
-        $args{SSL_options}{SSL_verify_mode}
-            = IO::Socket::SSL::SSL_VERIFY_NONE();
+        if ( $self->ssl_options ) {
+            $args{SSL_options} = $self->ssl_options();
+        } else {
+            $args{SSL_options}{SSL_verify_mode}
+                = IO::Socket::SSL::SSL_VERIFY_NONE();
+        }
     }
 
     return HTTP::Tiny->new( %args, %{ $self->handle_args } );

--- a/lib/Search/Elasticsearch/Cxn/LWP.pm
+++ b/lib/Search/Elasticsearch/Cxn/LWP.pm
@@ -70,7 +70,11 @@ sub _build_handle {
         parse_head => 0
     );
     if ( $self->is_https ) {
-        $args{ssl_opts} = { verify_hostname => 0 };
+        if ( $self->ssl_options ) {
+            $args{ssl_opts} = $self->ssl_options();
+        } else {
+            $args{ssl_opts} = { verify_hostname => 0 };
+        }
     }
     return LWP::UserAgent->new( %args, %{ $self->handle_args } );
 }

--- a/lib/Search/Elasticsearch/Cxn/NetCurl.pm
+++ b/lib/Search/Elasticsearch/Cxn/NetCurl.pm
@@ -70,6 +70,10 @@ sub perform_request {
         if %headers;
 
     if ( $self->is_https ) {
+        if ( $self->ssl_options ) {
+            die("NetCurl does not support ssl_options");
+        }
+
         $handle->setopt( CURLOPT_SSL_VERIFYPEER, 0 );
         $handle->setopt( CURLOPT_SSL_VERIFYHOST, 0 );
     }

--- a/lib/Search/Elasticsearch/Role/Cxn/HTTP.pm
+++ b/lib/Search/Elasticsearch/Role/Cxn/HTTP.pm
@@ -11,6 +11,7 @@ has 'is_https'           => ( is => 'ro' );
 has 'userinfo'           => ( is => 'ro' );
 has 'max_content_length' => ( is => 'ro' );
 has 'default_headers'    => ( is => 'ro' );
+has 'ssl_options'        => ( is => 'ro' );
 has 'handle'             => ( is => 'lazy', clearer => 1 );
 has '_pid'               => ( is => 'rw', default => $$ );
 
@@ -244,6 +245,12 @@ documented for those who are writing alternative implementations only.
     $scheme = $cxn->scheme;
 
 Returns the scheme of the connection, ie C<http> or C<https>.
+
+=head2 C<ssl_options()>
+
+    $ssl_options = $cxn->ssl_options
+
+The SSL options that are passed with each request to C<IO::Socket::SSL> or C<LWP::UserAgent>.
 
 =head2 C<is_https()>
 


### PR DESCRIPTION
Add support for specifying SSL options that will be honored by LWP and HTTPTiny
this way we can support client side certificates, server certificate and
hostname verification.

Example:

my $e = Search::Elasticsearch->new(nodes => ['https://'],
                                   ssl_options => {
                                       verify_hostname => 1,
                                       SSL_verifycn_name => 'server_name',
                                       SSL_ca_file => 'ca.crt',
                                       SSL_cert_file => 'client.all',
                                       SSL_key_file => 'client.all'
                                   }
                               );

There is one difference between HTTPTiny and LWP, where LWP requires verify_hostname
and HTTPTiny uses SSL_verify_mode from IO::Socket::SSL, this is caused by code in
LWP::Protocol::https.
