### PR TITLE
Save raw params for scrolling

### DIFF
--- a/lib/Search/Elasticsearch/Role/Scroll.pm
+++ b/lib/Search/Elasticsearch/Role/Scroll.pm
@@ -33,7 +33,7 @@ sub finish {
 sub scroll_request {
 #===================================
     my $self = shift;
-    my %args = ( scroll => $self->scroll );
+    my %args = ( scroll => $self->scroll, $self->search_params ? ( params => $self->search_params ) : () );
     if ( $self->scroll_in_qs ) {
         $args{scroll_id} = $self->_scroll_id;
     }

--- a/lib/Search/Elasticsearch/Scroll.pm
+++ b/lib/Search/Elasticsearch/Scroll.pm
@@ -37,6 +37,7 @@ sub BUILDARGS {
         total        => $total,
         max_score    => $results->{hits}{max_score},
         _buffer      => $results->{hits}{hits},
+        $params->{params} ? ( search_params => $params->{params}) : (),
         $total
         ? ( _scroll_id => $results->{_scroll_id} )
         : ( is_finished => 1 )


### PR DESCRIPTION
Not sure if the search_params value in the Search role was intended for this use, but I ran into this bug today and decided to fix it.  Thanks for putting this code up on github :)