### PR TITLE
Scroll fork protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ log
 bench_cxn.pl
 *.xml
 shield/*
+# App::CSE
+.cse*

--- a/lib/Search/Elasticsearch/Error.pm
+++ b/lib/Search/Elasticsearch/Error.pm
@@ -9,6 +9,7 @@ our $DEBUG = 0;
 @Search::Elasticsearch::Error::NoNodes::ISA      = __PACKAGE__;
 @Search::Elasticsearch::Error::Unauthorized::ISA = __PACKAGE__;
 @Search::Elasticsearch::Error::Forbidden::ISA    = __PACKAGE__;
+@Search::Elasticsearch::Error::Illegal::ISA      = __PACKAGE__;
 @Search::Elasticsearch::Error::Request::ISA      = __PACKAGE__;
 @Search::Elasticsearch::Error::Timeout::ISA      = __PACKAGE__;
 @Search::Elasticsearch::Error::Cxn::ISA          = __PACKAGE__;
@@ -243,6 +244,12 @@ Either the cluster was unable to process the request because it is currently
 blocking, eg there are not enough master nodes to form a cluster, or
 because the authenticated user is trying to perform an unauthorized
 action. This error is triggered by the C<403> HTTP status code.
+
+=item * C<Search::Elasticsearch::Error::Illegal>
+
+You have attempted to perform an illegal operation.
+For instance, you attempted to use a Scroll helper in a different process
+after forking.
 
 =item * C<Search::Elasticsearch::Error::Serializer>
 

--- a/lib/Search/Elasticsearch/Role/Scroll.pm
+++ b/lib/Search/Elasticsearch/Role/Scroll.pm
@@ -3,7 +3,6 @@ package Search::Elasticsearch::Role::Scroll;
 use Moo::Role;
 requires '_clear_scroll';
 use Search::Elasticsearch::Util qw(parse_params throw);
-use Scalar::Util qw(weaken blessed);
 use namespace::clean;
 
 has 'es' => ( is => 'ro', required => 1 );
@@ -19,11 +18,13 @@ has 'total_took'    => ( is => 'rwp' );
 has 'search_params' => ( is => 'ro' );
 has 'is_finished'   => ( is => 'rwp', default => '' );
 has '_scroll_id'    => ( is => 'rwp', clearer => 1, predicate => 1 );
+has '_pid'          => ( is => 'ro', default => $$ );
 
 #===================================
 sub finish {
 #===================================
     my $self = shift;
+    return unless ( $self->_pid() == $$ );
     return if $self->is_finished;
     $self->_set_is_finished(1);
     $self->_clear_scroll;
@@ -52,4 +53,4 @@ sub DEMOLISH {
 
 1;
 
-# ABSTRACT: Provides common functionality to L<Elasticseach::Scroll> and L<Search::Elasticsearch::Async::Scroll>
+# ABSTRACT: Provides common functionality to L<Search::Elasticseach::Scroll> and L<Search::Elasticsearch::Async::Scroll>


### PR DESCRIPTION
This implements issue #79 by doing two things:

- Avoid finishing a Scroll helper when the finishing process is not the one who created it.
- Crash with an Illegal exception when a programmer attempts to use the Async helper in a forked process.