### PR TITLE
don't use Moo in Search::Elasticsearch::Error

### DIFF
--- a/lib/Search/Elasticsearch/Error.pm
+++ b/lib/Search/Elasticsearch/Error.pm
@@ -1,7 +1,5 @@
 package Search::Elasticsearch::Error;
 
-use Moo;
-
 our $DEBUG = 0;
 
 @Search::Elasticsearch::Error::Internal::ISA     = __PACKAGE__;


### PR DESCRIPTION
This fixes "Unknown constructor for Search::Elasticsearch::Error already exists at (...)
perl5/lib/perl5/Method/Generate/Constructor.pm line 111. " errors we started to get in our app after Moo version bump