### PR TITLE
Fix for code typos in doc (missing ; and my). Fixes #84

### DIFF
--- a/lib/Search/Elasticsearch/Bulk.pm
+++ b/lib/Search/Elasticsearch/Bulk.pm
@@ -134,7 +134,7 @@ __END__
     $bulk->add_action( update => { id => 1, script => '...' });
 
     # Manual flush
-    $bulk->flush
+    $bulk->flush;
 
     # Reindex docs:
     my $bulk = $es->bulk_helper(

--- a/lib/Search/Elasticsearch/Scroll.pm
+++ b/lib/Search/Elasticsearch/Scroll.pm
@@ -219,7 +219,7 @@ C<client_id>:
         }
     );
 
-    while my ( $doc = $scroll->next ) {
+    while (my $doc = $scroll->next) {
         # do something
     }
 


### PR DESCRIPTION
I (and apparently @djzort) like to be able to copy and paste code directly from the documentation, so I fixed this two small typos where the code did not compile without editing. I have sign the CLA at http://www.elastic.co/contributor-agreement/ . (btw: this module works great. Thank you for your hard work :-) )