### PR TITLE
Search::Elasticsearch errors should be JSON-compatible

### DIFF
--- a/lib/Search/Elasticsearch/Error.pm
+++ b/lib/Search/Elasticsearch/Error.pm
@@ -151,6 +151,13 @@ sub stacktrace {
 
     return $o .= ( '-' x 80 ) . "\n";
 }
+
+#===================================
+sub TO_JSON {
+#===================================
+    my $self = shift;
+    return $self->_stringify;
+}
 1;
 
 # ABSTRACT: Errors thrown by Search::Elasticsearch
@@ -170,6 +177,12 @@ consists of the following:
 
 The C<$Search::Elasticsearch::Error::DEBUG> variable can be set to C<1> or C<2>
 to increase the verbosity of errors.
+
+Error objects stringify to a human readable error message when being used in text
+context (for example: C<print 'Oh no! '.$error>).
+
+It also stringifys when being converted to JSON and convert_blessed is enables.
+See the L<JSON> module for more information.
 
 =head1 ERROR CLASSES
 

--- a/t/30_Logger/80_error_json.t
+++ b/t/30_Logger/80_error_json.t
@@ -1,0 +1,20 @@
+use Test::More tests => 3;
+use Test::Exception;
+use lib 't/lib';
+
+use_ok('Search::Elasticsearch::Error');
+
+eval 'use JSON qw(to_json);';
+SKIP: {
+    skip 'JSON module not installed',2 if $@;
+    ok(my $es_error = Search::Elasticsearch::Error->new(
+        'Missing',
+        "Foo missing",
+        { code => 404 }
+    ),'Create test error');
+    like(
+	to_json({ eserr => $es_error}, { convert_blessed => 1 }),
+	qr/Foo missing/,
+	'to_json',
+    );
+}

--- a/t/30_Logger/80_error_json.t
+++ b/t/30_Logger/80_error_json.t
@@ -4,17 +4,17 @@ use lib 't/lib';
 
 use_ok('Search::Elasticsearch::Error');
 
-eval 'use JSON qw(to_json);';
+eval 'use JSON::PP;';
 SKIP: {
-    skip 'JSON module not installed',2 if $@;
+    skip 'JSON::PP module not installed',2 if $@;
     ok(my $es_error = Search::Elasticsearch::Error->new(
         'Missing',
         "Foo missing",
         { code => 404 }
     ),'Create test error');
     like(
-	to_json({ eserr => $es_error}, { convert_blessed => 1 }),
+	JSON::PP->new->convert_blessed(1)->encode({ eserr => $es_error}),
 	qr/Foo missing/,
-	'to_json',
+	'encode_json',
     );
 }


### PR DESCRIPTION
Converting a Search::Elasticsearch error to JSON (within some structure) fails like this:
`encountered object '[Request] ** [http://localhost:9200]-[400] SearchPhaseExecutionException[Failed to execute phase [query], all shards failed; [...] 'method' => 'GET'},'status_code' => 400}
', but neither allow_blessed nor convert_blessed settings are enabled at /usr/share/perl5/JSON.pm line 154.`

This is bad, because the Search::Elasticsearch::Error object stringifies in text context, also in the error message. Developers don't see that the error is an object and wonder why it can't be transported.

Avoiding these crashes is easy, because the JSON module offers a solution for objects to stringify themself. This pull request introduces JSON support for the error module.

PS: I tried to put the test into the best location, please move it if you want to have it at a different place.