### PR TITLE
Docs: add script_file example to bulk update

### DIFF
--- a/lib/Search/Elasticsearch/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Async/Bulk.pm
@@ -557,9 +557,7 @@ In this case, all you have to do is to pass in a list of IDs.
           doc_as_upsert => 1
         },
         { id            => 2,
-          lang          => 'mvel',
-          script        => '_ctx.source.counter+=incr',
-          params        => { incr => 1},
+          script        => { script },
           upsert        => { upsert doc }
         },
         ...
@@ -570,7 +568,7 @@ The C<update()> helper method allows you to add multiple C<update> actions.
 It accepts the same parameters as L<Search::Elasticsearch::Client::2_0::Direct/update()>.
 An update can either use a I<partial doc> which gets merged with an existing
 doc (example 1 above), or can use a C<script> to update an existing doc
-(example 2 above).
+(example 2 above). More information on C<script> can be found here: L<Search::Elasticsearch::Client::2_0::Direct/update()>.
 
 =head1 REINDEXING DOCUMENTS
 

--- a/lib/Search/Elasticsearch/Bulk.pm
+++ b/lib/Search/Elasticsearch/Bulk.pm
@@ -423,16 +423,9 @@ In this case, all you have to do is to pass in a list of IDs.
         },
         { id            => 2,
           lang          => 'mvel',
-          script        => '_ctx.source.counter+=incr',
-          params        => { incr => 1},
+          script        => { script }
           upsert        => { upsert doc }
         },
-        {
-          id            => 3,
-          lang          => 'groovy',
-          script_file   => 'counter'  # config/scripts/counter.groovy
-          params        => { incr => 42},
-        }
         ...
     );
 
@@ -441,7 +434,7 @@ The C<update()> helper method allows you to add multiple C<update> actions.
 It accepts the same parameters as L<Search::Elasticsearch::Client::2_0::Direct/update()>.
 An update can either use a I<partial doc> which gets merged with an existing
 doc (example 1 above), or can use a C<script> to update an existing doc
-(example 2 above). To use a script stored in a file, use C<script_file> (example 3).
+(example 2 above). More information on C<script> can be found here: L<Search::Elasticsearch::Client::2_0::Direct/update()>.
 
 =head1 REINDEXING DOCUMENTS
 

--- a/lib/Search/Elasticsearch/Bulk.pm
+++ b/lib/Search/Elasticsearch/Bulk.pm
@@ -427,6 +427,12 @@ In this case, all you have to do is to pass in a list of IDs.
           params        => { incr => 1},
           upsert        => { upsert doc }
         },
+        {
+          id            => 3,
+          lang          => 'groovy',
+          script_file   => 'counter'  # config/scripts/counter.groovy
+          params        => { incr => 42},
+        }
         ...
     );
 
@@ -435,7 +441,7 @@ The C<update()> helper method allows you to add multiple C<update> actions.
 It accepts the same parameters as L<Search::Elasticsearch::Client::2_0::Direct/update()>.
 An update can either use a I<partial doc> which gets merged with an existing
 doc (example 1 above), or can use a C<script> to update an existing doc
-(example 2 above).
+(example 2 above). To use a script stored in a file, use C<script_file> (example 3).
 
 =head1 REINDEXING DOCUMENTS
 

--- a/lib/Search/Elasticsearch/Client/2_0/Direct.pm
+++ b/lib/Search/Elasticsearch/Client/2_0/Direct.pm
@@ -463,15 +463,52 @@ C<index>, C<type> and C<id> if it exists. Updates can be performed either by:
         }
     );
 
-=item * or with a script:
+=item * with an inline script:
 
     $response = $e->update(
         ...,
         body => {
-            script => "ctx._source.counter += incr",
-            params => { incr => 5 }
+            script => {
+                inline => "ctx._source.counter += incr",
+                params => { incr => 5 }
+            }
         }
     );
+
+Make sure you enable
+L<dynamic scripting|https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html#enable-dynamic-scripting>
+and know its implications.
+
+=item * with an indexed script:
+
+    $response = $e->update(
+        ...,
+        body => {
+            script => {
+                id     => $id,
+                params => { incr => 5 }
+            }
+        }
+    );
+
+See L<indexed scripts|https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html#_indexed_scripts>
+for more information.
+
+=item * with a script stored as a file:
+
+    $response = $e->update(
+        ...,
+        body => {
+            script => {
+                file   => 'counter',
+                lang   => 'groovy',
+                params => { incr => 5 }
+            }
+        }
+    );
+
+See L<scripting docs|https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-scripting.html>
+for more information.
 
 =back
 


### PR DESCRIPTION
Hey

I had a hard time figuring out how to use a file-script (script-file?) in an update (mainly caused by the ElasticSearch docs themselves not being very clear about it, and the final revelation brought by this stackoverflow post http://stackoverflow.com/a/30372626 )

Anyway, I think the correct way is to use script_file (which I found in the source code, but not the docs).

So here's a small doc patch for the next person who need this...

One more note: I did not find script_file in the 2.0 API (Search::Elasticsearch::Role::API::2_0; around line 587). Is it missing there, or is script_file not allowed on a non-bulk update?

Thanks for the nice module!

Greetings,
domm
