### PR TITLE
Require YAML 0.95 which supports dumping blessed globs,

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -27,7 +27,7 @@ skip = Cpanel::JSON::XS
 base                                = 2.18
 Test::More                          = 0.98
 TAP::Harness::JUnit                 = 0
-YAML                                = 0
+YAML                                = 1.15
 
 [Prereqs / Recommends]
 URI::Escape::XS                     = 0

--- a/dist.ini
+++ b/dist.ini
@@ -27,7 +27,7 @@ skip = Cpanel::JSON::XS
 base                                = 2.18
 Test::More                          = 0.98
 TAP::Harness::JUnit                 = 0
-YAML                                = 1.15
+YAML                                = 0.95
 
 [Prereqs / Recommends]
 URI::Escape::XS                     = 0


### PR DESCRIPTION
Otherwise a scroll_helper with no hits will fail with `Code: Can't create YAML::Node from 'GLOB'`