### PR TITLE
TestServer shutdown() fixes

### DIFF
--- a/lib/Search/Elasticsearch/TestServer.pm
+++ b/lib/Search/Elasticsearch/TestServer.pm
@@ -17,6 +17,7 @@ has 'es_port'   => ( is => 'ro', default  => 9700 );
 has 'pids'      => ( is => 'ro', default  => sub { [] }, clearer => 1 , predicate => 1);
 has 'dir'       => ( is => 'ro', clearer  => 1 );
 has 'conf' => ( is => 'ro', default => sub { [] } );
+has '_starter_pid' => ( is => 'rw', required => 0, predicate => 1 );
 
 #===================================
 sub start {
@@ -112,9 +113,19 @@ sub _start_node {
                 unless $pid;
             chomp $pid;
             push @{ $self->{pids} }, $pid;
+            $self->_starter_pid($$);
         }
     }
     $SIG{INT}->('INT') if $int_caught;
+}
+
+#===================================
+sub guarded_shutdown {
+#===================================
+    my $self = shift;
+    if ( $self->_has_starter_pid && $$ == $self->_starter_pid ) {
+        $self->shutdown();
+    }
 }
 
 #===================================
@@ -157,7 +168,7 @@ sub _command_line {
 }
 
 #===================================
-sub DEMOLISH { shift->shutdown }
+sub DEMOLISH { shift->guarded_shutdown }
 #===================================
 
 1;

--- a/lib/Search/Elasticsearch/TestServer.pm
+++ b/lib/Search/Elasticsearch/TestServer.pm
@@ -14,7 +14,7 @@ has 'es_home'   => ( is => 'ro', required => 1 );
 has 'instances' => ( is => 'ro', default  => 1 );
 has 'http_port' => ( is => 'ro', default  => 9600 );
 has 'es_port'   => ( is => 'ro', default  => 9700 );
-has 'pids'      => ( is => 'ro', default  => sub { [] }, clearer => 1 );
+has 'pids'      => ( is => 'ro', default  => sub { [] }, clearer => 1 , predicate => 1);
 has 'dir'       => ( is => 'ro', clearer  => 1 );
 has 'conf' => ( is => 'ro', default => sub { [] } );
 
@@ -122,6 +122,8 @@ sub shutdown {
 #===================================
     my $self = shift;
     local $?;
+
+    return unless $self->has_pids;
 
     my $pids = $self->pids;
     $self->clear_pids;

--- a/t/95_TestServer/00_test_server.t
+++ b/t/95_TestServer/00_test_server.t
@@ -1,0 +1,66 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use File::Temp;
+use POSIX ":sys_wait_h";
+
+use Search::Elasticsearch;
+use Search::Elasticsearch::TestServer;
+
+my @pids;
+
+SKIP: {
+    skip 'ES_HOME not set', 7 unless $ENV{ES_HOME};
+
+    my $tempdir = File::Temp->newdir('testserver-XXXXX', DIR => '/tmp');
+    my $server = Search::Elasticsearch::TestServer->new(
+        es_home   => $ENV{ES_HOME},
+        conf      => ["path.data=$tempdir", "path.logs=$tempdir",]
+    );
+
+    my $nodes = $server->start();
+
+    ok($nodes, "server->start returned nodes") or diag explain {server => $server};
+    ok(defined($server->pids), "server->pids defined");
+    cmp_ok(scalar @{$server->pids}, '>', 0, "more than 0 pids");
+    @pids = @{$server->pids};
+
+    subtest 'ES pids are alive' => sub {
+        verify_pids_alive(@pids);
+    };
+
+    $server->shutdown;
+
+    note 'sleep to give ES time to die';
+    sleep 5;
+
+    subtest 'ES pids are dead after shutdown' => sub {
+        verify_pids_dead(@pids);
+    };
+
+    eval {$server->shutdown};
+    is($@, '', "second shutdown did not set error");
+
+    subtest 'ES pids are dead after second shutdown' => sub {
+        verify_pids_dead(@pids);
+    };
+}
+
+done_testing;
+
+#important to waitpid or kill0 will return true for zombies.
+sub verify_pids_alive {
+    for my $pid (@_) {
+        waitpid($pid, WNOHANG);
+        ok(kill(0, $pid), "pid $pid is alive");
+    }
+}
+
+sub verify_pids_dead {
+    for my $pid (@_) {
+        waitpid($pid, WNOHANG);
+        ok(! kill(0, $pid), "pid $pid is dead");
+    }
+}

--- a/t/95_TestServer/10_test_server_fork.t
+++ b/t/95_TestServer/10_test_server_fork.t
@@ -1,0 +1,75 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Test::SharedFork;
+
+use File::Temp;
+use POSIX ":sys_wait_h";
+
+use Search::Elasticsearch;
+use Search::Elasticsearch::TestServer;
+
+my $pids = [];
+
+SKIP: {
+    skip 'ES_HOME not set', 8 unless $ENV{ES_HOME};
+
+    my $tempdir = File::Temp->newdir('testserver-XXXXX', DIR => '/tmp');
+    my $server = Search::Elasticsearch::TestServer->new(
+        es_home   => $ENV{ES_HOME},
+        conf      => ["path.data=$tempdir", "path.logs=$tempdir",]
+    );
+
+    my $nodes = $server->start();
+
+    ok($nodes, "server->start returned nodes") or diag explain {server => $server};
+    ok(defined($server->pids), "server->pids defined");
+    cmp_ok(scalar @{$server->pids}, '>', 0, "more than 0 pids");
+    $pids = \@{$server->pids};
+
+    verify_pids_alive($pids, 'ES pids are alive');
+
+    {
+        my $pid = fork;
+        die "cannot fork" unless defined $pid;
+
+        if ($pid == 0) {
+            verify_pids_alive($pids, 'ES pids are alive in child');
+            exit 0;
+        } else {
+            verify_pids_alive($pids, 'ES pids are alive in parent');
+            waitpid($pid, 0);
+            sleep 5;
+            verify_pids_alive($pids, 'ES pids are alive in parent after child dies');
+        }
+    }
+
+    $server->shutdown;
+
+    note 'sleep to give ES time to die';
+    sleep 5;
+
+    verify_pids_dead($pids, 'ES pids are dead after shutdown');
+
+};
+done_testing;
+
+#important to waitpid or kill0 will return true for zombies.
+sub verify_pids_alive {
+    my ($pids, $msg) = @_;
+    $msg = '' if !defined $msg;
+    for my $pid (@$pids) {
+        waitpid($pid, WNOHANG);
+        ok(kill(0, $pid), "$msg: pid $pid is alive");
+    }
+}
+
+sub verify_pids_dead {
+    my ($pids, $msg) = @_;
+    $msg = '' if !defined $msg;
+    for my $pid (@$pids) {
+        waitpid($pid, WNOHANG);
+        ok(! kill(0, $pid), "$msg: pid $pid is dead");
+    }
+}

--- a/test/run_yaml_tests.pl
+++ b/test/run_yaml_tests.pl
@@ -34,6 +34,7 @@ $ENV{ES_CXN}   = $cxn;
 $ENV{TRACE}    = $trace;
 $ENV{ES} ||= "localhost:9200";
 $ENV{ES_PLUGINS} = join ",", @plugins;
+$ENV{ES_HOME} ||= "/usr/share/elasticsearch/";
 
 my $tap = $harness->new(
     {   exec      => [ $^X, 'test/yaml_tester.pl' ],


### PR DESCRIPTION
Adds tests and fixes for #93 and #94.

Please take a look at the code and the new tests, and let me know if these changes seem appropriate.  e.g., I'm not in love with the name `guared_shutdown`, if you have a name that better fits your scheme.

Note, I have signed and verified the Contributor agreement.

Closes #93 
Closes #94