### PR TITLE
fix link in abstract

### DIFF
--- a/lib/Search/Elasticsearch/Role/Bulk.pm
+++ b/lib/Search/Elasticsearch/Role/Bulk.pm
@@ -270,4 +270,4 @@ sub _doc_transformer {
 
 1;
 
-# ABSTRACT: Provides common functionality to L<Elasticseach::Bulk> and L<Search::Elasticsearch::Async::Bulk>
+# ABSTRACT: Provides common functionality to L<Search::Elasticseach::Bulk> and L<Search::Elasticsearch::Async::Bulk>


### PR DESCRIPTION
links to a not-found page, see: https://metacpan.org/pod/Search::Elasticsearch::Role::Bulk
