### PR TITLE
fix spelling mistakes

### DIFF
--- a/lib/Search/Elasticsearch/Client/5_0/Direct/Ingest.pm
+++ b/lib/Search/Elasticsearch/Client/5_0/Direct/Ingest.pm
@@ -27,7 +27,7 @@ It does L<Search::Elasticsearch::Role::Client::Direct>.
         body => { pipeline defn }   # required
     );
 
-The C<put_pipeline()> method creates or updates a pipeline with the specfied ID.
+The C<put_pipeline()> method creates or updates a pipeline with the specified ID.
 
 Query string parameters:
     C<master_timeout>,
@@ -57,7 +57,7 @@ for more information.
         id   => $id,                # required
     );
 
-The C<delete_pipeline()> method deletes the pipeline with the specfied ID.
+The C<delete_pipeline()> method deletes the pipeline with the specified ID.
 
 Query string parameters:
     C<master_timeout>,


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Search-Elasticsearch.
We thought you might be interested in it too.

    Description: fix spelling mistakes
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2016-12-17
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libsearch-elasticsearch-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
