### PR TITLE
Fix long passwords breaking HTTP Basic Auth

### DIFF
--- a/lib/Search/Elasticsearch/Role/Cxn.pm
+++ b/lib/Search/Elasticsearch/Role/Cxn.pm
@@ -100,7 +100,7 @@ sub BUILDARGS {
 
     if ($userinfo) {
         require MIME::Base64;
-        my $auth = MIME::Base64::encode_base64($userinfo,"");
+        my $auth = MIME::Base64::encode_base64( $userinfo, "" );
         chomp $auth;
         $default_headers{Authorization} = "Basic $auth";
     }
@@ -113,13 +113,13 @@ sub BUILDARGS {
         $default_headers{'Accept-Encoding'} = "deflate";
     }
 
-    $params->{scheme}          = $scheme;
-    $params->{is_https}        = $scheme eq 'https';
-    $params->{host}            = $host;
-    $params->{port}            = $port;
-    $params->{path}            = $path;
-    $params->{userinfo}        = $userinfo;
-    $host                      = "[$host]" if Net::IP::ip_is_ipv6($host);
+    $params->{scheme}   = $scheme;
+    $params->{is_https} = $scheme eq 'https';
+    $params->{host}     = $host;
+    $params->{port}     = $port;
+    $params->{path}     = $path;
+    $params->{userinfo} = $userinfo;
+    $host = "[$host]" if Net::IP::ip_is_ipv6($host);
     $params->{uri}             = URI->new("$scheme://$host:$port$path");
     $params->{default_headers} = \%default_headers;
 
@@ -308,7 +308,7 @@ sub process_response {
     # Deprecation warnings
     if ( my $warnings = $headers->{warning} ) {
         my $warning_string = _parse_warnings($warnings);
-        my %temp = (%$params);
+        my %temp           = (%$params);
         delete $temp{data};
         $self->logger->deprecation( $warning_string, \%temp );
     }
@@ -368,8 +368,7 @@ sub _parse_warnings {
     for (@warnings) {
         if ( $_ =~ /^\d+\s+\S+\s+"((?:\\"|[^"])+)"/ ) {
             my $msg = $1;
-            $msg=~s/\\"/"/g,
-            push @str, $msg;
+            $msg =~ s/\\"/"/g, push @str, $msg;
         }
         else {
             push @str, $_;

--- a/lib/Search/Elasticsearch/Role/Cxn.pm
+++ b/lib/Search/Elasticsearch/Role/Cxn.pm
@@ -100,7 +100,7 @@ sub BUILDARGS {
 
     if ($userinfo) {
         require MIME::Base64;
-        my $auth = MIME::Base64::encode_base64($userinfo);
+        my $auth = MIME::Base64::encode_base64($userinfo,"");
         chomp $auth;
         $default_headers{Authorization} = "Basic $auth";
     }

--- a/t/60_Cxn/30_http.t
+++ b/t/60_Cxn/30_http.t
@@ -9,7 +9,7 @@ sub is_cxn(@);
 my $username     = 'ThisIsAVeryLongUsernameAndThatIsOKYouSee';
 my $password     = 'CorrectHorseBatteryStapleCorrectHorseBatteryStaple';
 my $userinfo     = "$username:$password";
-my $userinfo_b64 = MIME::Base64::encode_base64($userinfo,"");
+my $userinfo_b64 = MIME::Base64::encode_base64( $userinfo, "" );
 
 ### Scalar nodes ###
 
@@ -47,33 +47,49 @@ is_cxn "IPv4",
     new_cxn( nodes => '127.0.0.1' ),
     { host => '127.0.0.1', port => '80', uri => 'http://127.0.0.1:80' };
 
-is_cxn "Scheme:IPv4",
-    new_cxn( nodes => 'https://127.0.0.1' ),
-    { host => '127.0.0.1', port => '443', uri => 'https://127.0.0.1:443', scheme => 'https' };
+is_cxn "Scheme:IPv4", new_cxn( nodes => 'https://127.0.0.1' ),
+    {
+    host   => '127.0.0.1',
+    port   => '443',
+    uri    => 'https://127.0.0.1:443',
+    scheme => 'https'
+    };
 
 is_cxn "IPv4:Port",
     new_cxn( nodes => '127.0.0.1:1000' ),
     { host => '127.0.0.1', port => '1000', uri => 'http://127.0.0.1:1000' };
 
-is_cxn "Scheme:IPv4:Port",
-    new_cxn( nodes => 'https://127.0.0.1:1000' ),
-    { host => '127.0.0.1', port => '1000', uri => 'https://127.0.0.1:1000', scheme => 'https' };
+is_cxn "Scheme:IPv4:Port", new_cxn( nodes => 'https://127.0.0.1:1000' ),
+    {
+    host   => '127.0.0.1',
+    port   => '1000',
+    uri    => 'https://127.0.0.1:1000',
+    scheme => 'https'
+    };
 
 is_cxn "IPv6",
     new_cxn( nodes => '::1' ),
     { host => '::1', port => '80', uri => 'http://[::1]:80' };
 
-is_cxn "Scheme:IPv6",
-    new_cxn( nodes => 'https://[::1]' ),
-    { host => '::1', port => '443', uri => 'https://[::1]:443', scheme => 'https' };
+is_cxn "Scheme:IPv6", new_cxn( nodes => 'https://[::1]' ),
+    {
+    host   => '::1',
+    port   => '443',
+    uri    => 'https://[::1]:443',
+    scheme => 'https'
+    };
 
 is_cxn "IPv6:Port",
     new_cxn( nodes => '[::1]:1000' ),
     { host => '::1', port => '1000', uri => 'http://[::1]:1000' };
 
-is_cxn "Scheme:IPv6:Port",
-    new_cxn( nodes => 'https://[::1]:1000' ),
-    { host => '::1', port => '1000', uri => 'https://[::1]:1000', scheme => 'https' };
+is_cxn "Scheme:IPv6:Port", new_cxn( nodes => 'https://[::1]:1000' ),
+    {
+    host   => '::1',
+    port   => '1000',
+    uri    => 'https://[::1]:1000',
+    scheme => 'https'
+    };
 
 ### Options with scalar ###
 
@@ -115,6 +131,7 @@ is_cxn "Userinfo option", new_cxn( nodes => 'foo', userinfo => $userinfo ),
     };
 
 is_cxn "Userinfo option with settings",
+
     # Note that userinfo as specified is explicitly different to that
     # provided in the nodes string
     new_cxn( nodes => "$userinfo\@foo", userinfo => 'foo:baz' ),
@@ -131,11 +148,11 @@ is_cxn "Deflate option",
     { default_headers => { 'Accept-Encoding' => 'deflate' } };
 
 is_cxn "IPv4 with Port",
-    new_cxn( nodes => '127.0.0.1', port => 456),
+    new_cxn( nodes => '127.0.0.1', port => 456 ),
     { host => '127.0.0.1', port => '456', uri => 'http://127.0.0.1:456' };
 
 is_cxn "IPv6 with Port",
-    new_cxn( nodes => '::1', port => 456),
+    new_cxn( nodes => '::1', port => 456 ),
     { host => '::1', port => '456', uri => 'http://[::1]:456' };
 
 ### Hash ###
@@ -176,10 +193,9 @@ is new_cxn( { default_qs_params => { session => 'key' } } )
 my $uri = new_cxn( { default_qs_params => { session => 'key' } } )
     ->build_uri( { path => '/_search', qs => { foo => 'bar' } } );
 
-like $uri, qr{^http://localhost:9200/_search?},
-    "default_qs_params and qs - 1";
-like $uri, qr{session=key}, "default_qs_params and qs - 2";
-like $uri, qr{foo=bar},     "default_qs_params and qs - 3";
+like $uri, qr{^http://localhost:9200/_search?}, "default_qs_params and qs - 1";
+like $uri, qr{session=key},                     "default_qs_params and qs - 2";
+like $uri, qr{foo=bar},                         "default_qs_params and qs - 3";
 
 is new_cxn( { default_qs_params => { session => 'key' } } )
     ->build_uri( { path => '/_search', qs => { session => 'bar' } } ),

--- a/t/60_Cxn_Async/30_http.t
+++ b/t/60_Cxn_Async/30_http.t
@@ -47,8 +47,7 @@ is_cxn "IPv4",
     new_cxn( nodes => '127.0.0.1' ),
     { host => '127.0.0.1', port => '80', uri => 'http://127.0.0.1:80' };
 
-is_cxn "Scheme:IPv4",
-    new_cxn( nodes => 'https://127.0.0.1' ),
+is_cxn "Scheme:IPv4", new_cxn( nodes => 'https://127.0.0.1' ),
     {
     host   => '127.0.0.1',
     port   => '443',
@@ -60,8 +59,7 @@ is_cxn "IPv4:Port",
     new_cxn( nodes => '127.0.0.1:1000' ),
     { host => '127.0.0.1', port => '1000', uri => 'http://127.0.0.1:1000' };
 
-is_cxn "Scheme:IPv4:Port",
-    new_cxn( nodes => 'https://127.0.0.1:1000' ),
+is_cxn "Scheme:IPv4:Port", new_cxn( nodes => 'https://127.0.0.1:1000' ),
     {
     host   => '127.0.0.1',
     port   => '1000',
@@ -73,8 +71,7 @@ is_cxn "IPv6",
     new_cxn( nodes => '::1' ),
     { host => '::1', port => '80', uri => 'http://[::1]:80' };
 
-is_cxn "Scheme:IPv6",
-    new_cxn( nodes => 'https://[::1]' ),
+is_cxn "Scheme:IPv6", new_cxn( nodes => 'https://[::1]' ),
     {
     host   => '::1',
     port   => '443',
@@ -86,8 +83,7 @@ is_cxn "IPv6:Port",
     new_cxn( nodes => '[::1]:1000' ),
     { host => '::1', port => '1000', uri => 'http://[::1]:1000' };
 
-is_cxn "Scheme:IPv6:Port",
-    new_cxn( nodes => 'https://[::1]:1000' ),
+is_cxn "Scheme:IPv6:Port", new_cxn( nodes => 'https://[::1]:1000' ),
     {
     host   => '::1',
     port   => '1000',
@@ -152,11 +148,11 @@ is_cxn "Deflate option",
     { default_headers => { 'Accept-Encoding' => 'deflate' } };
 
 is_cxn "IPv4 with Port",
-    new_cxn( nodes => '127.0.0.1', port => 456),
+    new_cxn( nodes => '127.0.0.1', port => 456 ),
     { host => '127.0.0.1', port => '456', uri => 'http://127.0.0.1:456' };
 
 is_cxn "IPv6 with Port",
-    new_cxn( nodes => '::1', port => 456),
+    new_cxn( nodes => '::1', port => 456 ),
     { host => '::1', port => '456', uri => 'http://[::1]:456' };
 
 ### Hash ###
@@ -197,10 +193,9 @@ is new_cxn( { default_qs_params => { session => 'key' } } )
 my $uri = new_cxn( { default_qs_params => { session => 'key' } } )
     ->build_uri( { path => '/_search', qs => { foo => 'bar' } } );
 
-like $uri, qr{^http://localhost:9200/_search?},
-    "default_qs_params and qs - 1";
-like $uri, qr{session=key}, "default_qs_params and qs - 2";
-like $uri, qr{foo=bar},     "default_qs_params and qs - 3";
+like $uri, qr{^http://localhost:9200/_search?}, "default_qs_params and qs - 1";
+like $uri, qr{session=key},                     "default_qs_params and qs - 2";
+like $uri, qr{foo=bar},                         "default_qs_params and qs - 3";
 
 is new_cxn( { default_qs_params => { session => 'key' } } )
     ->build_uri( { path => '/_search', qs => { session => 'bar' } } ),

--- a/t/60_Cxn_Async/30_http.t
+++ b/t/60_Cxn_Async/30_http.t
@@ -2,8 +2,14 @@ use Test::More;
 use Test::Exception;
 use Test::Deep;
 use Search::Elasticsearch::Async;
+use MIME::Base64;
 
 sub is_cxn(@);
+
+my $username     = 'ThisIsAVeryLongUsernameAndThatIsOKYouSee';
+my $password     = 'CorrectHorseBatteryStapleCorrectHorseBatteryStaple';
+my $userinfo     = "$username:$password";
+my $userinfo_b64 = MIME::Base64::encode_base64( $userinfo, "" );
 
 ### Scalar nodes ###
 
@@ -29,12 +35,12 @@ is_cxn "Path",
     new_cxn( nodes => 'foo/bar' ),
     { host => 'foo', port => '80', uri => 'http://foo:80/bar' };
 
-is_cxn "Userinfo", new_cxn( nodes => 'http://foo:bar@localhost/' ),
+is_cxn "Userinfo", new_cxn( nodes => "http://$userinfo\@localhost/" ),
     {
     port            => '80',
     uri             => 'http://localhost:80',
-    default_headers => { Authorization => 'Basic Zm9vOmJhcg==' },
-    userinfo        => 'foo:bar'
+    default_headers => { Authorization => "Basic $userinfo_b64" },
+    userinfo        => $userinfo
     };
 
 is_cxn "IPv4",
@@ -119,23 +125,26 @@ is_cxn "Path option with settings",
     new_cxn( nodes => 'foo/baz/', path_prefix => '/bar/' ),
     { host => 'foo', port => 80, uri => 'http://foo:80/baz' };
 
-is_cxn "Userinfo option", new_cxn( nodes => 'foo', userinfo => 'foo:bar' ),
+is_cxn "Userinfo option", new_cxn( nodes => 'foo', userinfo => $userinfo ),
     {
     host            => 'foo',
     port            => 80,
     uri             => 'http://foo:80',
-    default_headers => { Authorization => 'Basic Zm9vOmJhcg==' },
-    userinfo        => 'foo:bar'
+    default_headers => { Authorization => "Basic $userinfo_b64" },
+    userinfo        => $userinfo
     };
 
 is_cxn "Userinfo option with settings",
-    new_cxn( nodes => 'foo:bar@foo', userinfo => 'foo:baz' ),
+
+    # Note that userinfo as specified is explicitly different to that
+    # provided in the nodes string
+    new_cxn( nodes => "$userinfo\@foo", userinfo => 'foo:baz' ),
     {
     host            => 'foo',
     port            => 80,
     uri             => 'http://foo:80',
-    default_headers => { Authorization => 'Basic Zm9vOmJhcg==' },
-    userinfo        => 'foo:bar'
+    default_headers => { Authorization => "Basic $userinfo_b64" },
+    userinfo        => $userinfo
     };
 
 is_cxn "Deflate option",


### PR DESCRIPTION
Defaults in MIME::Base64 insert a newline at 76 characters.  The combination of a long username or password can cause the encoded base64 string to be longer than 76 characters, which breaks the HTTP basic auth header:

Thu Dec 6 15:06:24 2018] # ERROR: Search::Elasticsearch::Error::Request [https://elastic.cluster:443]-[599] Invalid HTTP header field value (Authorization): Basic dXNlcm5hbWU6VGhlIE1hZ2ljIFdvcmRzIGFyZSBTcXVlYW1pc2ggT3NzaWZyYWdlIEZvciBFbGFz\ndGljc2VhcmNoIExvbmcgUGFzc3dvcmRzCg==

This one-line patch kills the EOL character in encoded basic auth.