### PR TITLE
Allow long username and/or passwords

### DIFF
--- a/lib/Search/Elasticsearch/Role/Cxn.pm
+++ b/lib/Search/Elasticsearch/Role/Cxn.pm
@@ -100,7 +100,7 @@ sub BUILDARGS {
 
     if ($userinfo) {
         require MIME::Base64;
-        my $auth = MIME::Base64::encode_base64($userinfo);
+        my $auth = MIME::Base64::encode_base64($userinfo, '');
         chomp $auth;
         $default_headers{Authorization} = "Basic $auth";
     }


### PR DESCRIPTION
When using a sufficiently long username and password combination the basic auth header can end up being encoded to a multiline string. 

This is easily fixed by setting EOL character to be empty.

A simple workaround is to set default_headers with the encoded string and leave $userinfo unset.

```perl
require MIME::Base64;
my $auth = MIME::Base64::encode_base64('username:password');

my $e = Search::Elasticsearch->new(
    default_headers => { Authorization => 'Basic ' . $auth},
    nodes           => 'auth-search.example.com:9200',
);
``` 