### PR TITLE
Replace Try::Tiny

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -34,7 +34,6 @@ requires "Promises" => "0.93";
 requires "Scalar::Util" => "0";
 requires "Sub::Exporter" => "0";
 requires "Time::HiRes" => "0";
-requires "Try::Tiny" => "0";
 requires "URI" => "0";
 requires "namespace::clean" => "0";
 requires "overload" => "0";

--- a/lib/Search/Elasticsearch/Client/0_90/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/0_90/Async/Bulk.pm
@@ -7,7 +7,6 @@ with 'Search::Elasticsearch::Client::0_90::Role::Bulk',
 use Search::Elasticsearch::Util qw(parse_params throw);
 use Scalar::Util qw(weaken blessed);
 use Promises qw(deferred);
-use Try::Tiny;
 use namespace::clean;
 
 has 'on_fatal' => ( is => 'lazy' );
@@ -36,14 +35,13 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = try {
+            my @json = eval {
                 $self->_encode_action( splice( @actions, 0, 2 ) );
-            }
-            catch {
-                $self->on_fatal->($_);
-                $deferred->reject($_);
-                ();
             };
+            if ($@) {
+                $self->on_fatal->($@);
+                $deferred->reject($@);
+            }
             return unless @json;
 
             push @$buffer, @json;

--- a/lib/Search/Elasticsearch/Client/0_90/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/0_90/Async/Bulk.pm
@@ -35,12 +35,14 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = eval {
-                $self->_encode_action( splice( @actions, 0, 2 ) );
-            };
-            if ($@) {
-                $self->on_fatal->($@);
-                $deferred->reject($@);
+            my @json;
+            unless (eval {
+                @json = $self->_encode_action( splice( @actions, 0, 2 ) );
+                1;
+            }) {
+                my $error = $@;
+                $self->on_fatal->($error);
+                $deferred->reject($error);
             }
             return unless @json;
 

--- a/lib/Search/Elasticsearch/Client/0_90/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/0_90/Bulk.pm
@@ -4,7 +4,6 @@ use Moo;
 with 'Search::Elasticsearch::Client::0_90::Role::Bulk',
     'Search::Elasticsearch::Role::Is_Sync';
 use Search::Elasticsearch::Util qw(parse_params throw);
-use Try::Tiny;
 use namespace::clean;
 
 #===================================
@@ -49,18 +48,18 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = try {
+    my $results = eval {
         my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
         return $res;
-    }
-    catch {
-        my $error = $_;
+    };
+    if ($@) {
+        my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );
 
         die $error;
-    };
+    }
     $self->_report( $buffer, $results );
     return defined wantarray ? $results : undef;
 }

--- a/lib/Search/Elasticsearch/Client/0_90/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/0_90/Bulk.pm
@@ -48,12 +48,12 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = eval {
-        my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
+    my $results;
+    unless (eval {
+        $results = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
-        return $res;
-    };
-    if ($@) {
+        1;
+    }) {
         my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );

--- a/lib/Search/Elasticsearch/Client/1_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/1_0/Async/Bulk.pm
@@ -35,12 +35,14 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = eval {
-                $self->_encode_action( splice( @actions, 0, 2 ) );
-            };
-            if ($@) {
-                $self->on_fatal->($@);
-                $deferred->reject($@);
+            my @json;
+            unless (eval {
+                @json = $self->_encode_action( splice( @actions, 0, 2 ) );
+                1;
+            }) {
+                my $error = $@;
+                $self->on_fatal->($error);
+                $deferred->reject($error);
             }
             return unless @json;
 

--- a/lib/Search/Elasticsearch/Client/1_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/1_0/Async/Bulk.pm
@@ -7,7 +7,6 @@ with 'Search::Elasticsearch::Client::1_0::Role::Bulk',
 use Search::Elasticsearch::Util qw(parse_params throw);
 use Scalar::Util qw(weaken blessed);
 use Promises qw(deferred);
-use Try::Tiny;
 use namespace::clean;
 
 has 'on_fatal' => ( is => 'lazy' );
@@ -36,14 +35,13 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = try {
+            my @json = eval {
                 $self->_encode_action( splice( @actions, 0, 2 ) );
-            }
-            catch {
-                $self->on_fatal->($_);
-                $deferred->reject($_);
-                ();
             };
+            if ($@) {
+                $self->on_fatal->($@);
+                $deferred->reject($@);
+            }
             return unless @json;
 
             push @$buffer, @json;

--- a/lib/Search/Elasticsearch/Client/1_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/1_0/Bulk.pm
@@ -4,7 +4,6 @@ use Moo;
 with 'Search::Elasticsearch::Client::1_0::Role::Bulk',
     'Search::Elasticsearch::Role::Is_Sync';
 use Search::Elasticsearch::Util qw(parse_params throw);
-use Try::Tiny;
 use namespace::clean;
 
 #===================================
@@ -49,18 +48,18 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = try {
+    my $results = eval {
         my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
         return $res;
-    }
-    catch {
-        my $error = $_;
+    };
+    if ($@) {
+        my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );
 
         die $error;
-    };
+    }
     $self->_report( $buffer, $results );
     return defined wantarray ? $results : undef;
 }

--- a/lib/Search/Elasticsearch/Client/1_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/1_0/Bulk.pm
@@ -48,12 +48,12 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = eval {
-        my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
+    my $results;
+    unless (eval {
+        $results = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
-        return $res;
-    };
-    if ($@) {
+        1;
+    }) {
         my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );

--- a/lib/Search/Elasticsearch/Client/2_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/2_0/Async/Bulk.pm
@@ -35,12 +35,14 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = eval {
-                $self->_encode_action( splice( @actions, 0, 2 ) );
-            };
-            if ($@) {
-                $self->on_fatal->($@);
-                $deferred->reject($@);
+            my @json;
+            unless (eval {
+                @json = $self->_encode_action( splice( @actions, 0, 2 ) );
+                1;
+            }) {
+                my $error = $@;
+                $self->on_fatal->($error);
+                $deferred->reject($error);
             }
             return unless @json;
 

--- a/lib/Search/Elasticsearch/Client/2_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/2_0/Async/Bulk.pm
@@ -7,7 +7,6 @@ with 'Search::Elasticsearch::Client::2_0::Role::Bulk',
 use Search::Elasticsearch::Util qw(parse_params throw);
 use Scalar::Util qw(weaken blessed);
 use Promises qw(deferred);
-use Try::Tiny;
 use namespace::clean;
 
 has 'on_fatal' => ( is => 'lazy' );
@@ -36,14 +35,13 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = try {
+            my @json = eval {
                 $self->_encode_action( splice( @actions, 0, 2 ) );
-            }
-            catch {
-                $self->on_fatal->($_);
-                $deferred->reject($_);
-                ();
             };
+            if ($@) {
+                $self->on_fatal->($@);
+                $deferred->reject($@);
+            }
             return unless @json;
 
             push @$buffer, @json;

--- a/lib/Search/Elasticsearch/Client/2_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/2_0/Bulk.pm
@@ -48,12 +48,12 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = eval {
-        my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
+    my $results;
+    unless (eval {
+        $results = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
-        return $res;
-    };
-    if ($@) {
+        1;
+    }) {
         my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );

--- a/lib/Search/Elasticsearch/Client/2_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/2_0/Bulk.pm
@@ -4,7 +4,6 @@ use Moo;
 with 'Search::Elasticsearch::Client::2_0::Role::Bulk',
     'Search::Elasticsearch::Role::Is_Sync';
 use Search::Elasticsearch::Util qw(parse_params throw);
-use Try::Tiny;
 use namespace::clean;
 
 #===================================
@@ -49,18 +48,18 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = try {
+    my $results = eval {
         my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
         return $res;
-    }
-    catch {
-        my $error = $_;
+    };
+    if ($@) {
+        my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );
 
         die $error;
-    };
+    }
     $self->_report( $buffer, $results );
     return defined wantarray ? $results : undef;
 }

--- a/lib/Search/Elasticsearch/Client/5_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/5_0/Async/Bulk.pm
@@ -35,12 +35,14 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = eval {
-                $self->_encode_action( splice( @actions, 0, 2 ) );
-            };
-            if ($@) {
-                $self->on_fatal->($@);
-                $deferred->reject($@);
+            my @json;
+            unless (eval {
+                @json = $self->_encode_action( splice( @actions, 0, 2 ) );
+                1;
+            }) {
+                my $error = $@;
+                $self->on_fatal->($error);
+                $deferred->reject($error);
             }
             return unless @json;
 

--- a/lib/Search/Elasticsearch/Client/5_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/5_0/Async/Bulk.pm
@@ -7,7 +7,6 @@ with 'Search::Elasticsearch::Client::5_0::Role::Bulk',
 use Search::Elasticsearch::Util qw(parse_params throw);
 use Scalar::Util qw(weaken blessed);
 use Promises qw(deferred);
-use Try::Tiny;
 use namespace::clean;
 
 has 'on_fatal' => ( is => 'lazy' );
@@ -36,14 +35,13 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = try {
+            my @json = eval {
                 $self->_encode_action( splice( @actions, 0, 2 ) );
-            }
-            catch {
-                $self->on_fatal->($_);
-                $deferred->reject($_);
-                ();
             };
+            if ($@) {
+                $self->on_fatal->($@);
+                $deferred->reject($@);
+            }
             return unless @json;
 
             push @$buffer, @json;

--- a/lib/Search/Elasticsearch/Client/5_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/5_0/Bulk.pm
@@ -4,7 +4,6 @@ use Moo;
 with 'Search::Elasticsearch::Client::5_0::Role::Bulk',
     'Search::Elasticsearch::Role::Is_Sync';
 use Search::Elasticsearch::Util qw(parse_params throw);
-use Try::Tiny;
 use namespace::clean;
 
 #===================================
@@ -49,13 +48,13 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = try {
+    my $results = eval {
         my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
         return $res;
-    }
-    catch {
-        my $error = $_;
+    };
+    if ($@) {
+        my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );
 

--- a/lib/Search/Elasticsearch/Client/5_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/5_0/Bulk.pm
@@ -48,12 +48,12 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = eval {
-        my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
+    my $results;
+    unless (eval {
+        $results = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
-        return $res;
-    };
-    if ($@) {
+        1;
+    }) {
         my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );

--- a/lib/Search/Elasticsearch/Client/6_0/Async/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/6_0/Async/Bulk.pm
@@ -35,12 +35,14 @@ sub add_action {
     my $weak_add;
     my $add = sub {
         while (@actions) {
-            my @json = eval {
-                $self->_encode_action( splice( @actions, 0, 2 ) );
-            };
-            if ($@) {
-                $self->on_fatal->($@);
-                $deferred->reject($@);
+            my @json;
+            unless (eval {
+                @json = $self->_encode_action( splice( @actions, 0, 2 ) );
+                1;
+            }) {
+                my $error = $@;
+                $self->on_fatal->($error);
+                $deferred->reject($error);
             }
             return unless @json;
 

--- a/lib/Search/Elasticsearch/Client/6_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/6_0/Bulk.pm
@@ -48,12 +48,12 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = eval {
-        my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
+    my $results;
+    unless (eval {
+        $results = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
-        return $res;
-    };
-    if ($@) {
+        1;
+    }) {
         my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );

--- a/lib/Search/Elasticsearch/Client/6_0/Bulk.pm
+++ b/lib/Search/Elasticsearch/Client/6_0/Bulk.pm
@@ -4,7 +4,6 @@ use Moo;
 with 'Search::Elasticsearch::Client::6_0::Role::Bulk',
     'Search::Elasticsearch::Role::Is_Sync';
 use Search::Elasticsearch::Util qw(parse_params throw);
-use Try::Tiny;
 use namespace::clean;
 
 #===================================
@@ -49,18 +48,18 @@ sub flush {
         print ".";
     }
     my $buffer  = $self->_buffer;
-    my $results = try {
+    my $results = eval {
         my $res = $self->es->bulk( %{ $self->_bulk_args }, body => $buffer );
         $self->clear_buffer;
         return $res;
-    }
-    catch {
-        my $error = $_;
+    };
+    if ($@) {
+        my $error = $@;
         $self->clear_buffer
             unless $error->is( 'Cxn', 'NoNodes' );
 
         die $error;
-    };
+    }
     $self->_report( $buffer, $results );
     return defined wantarray ? $results : undef;
 }

--- a/lib/Search/Elasticsearch/Cxn/AEHTTP.pm
+++ b/lib/Search/Elasticsearch/Cxn/AEHTTP.pm
@@ -48,7 +48,7 @@ sub perform_request {
         ( $self->is_https ? ( tls_ctx => $self->_tls_ctx ) : () ),
         sub {
             my ( $body, $headers ) = @_;
-            eval {
+            unless (eval {
                 my ( $code, $response ) = $self->process_response(
                     $params,                      # request
                     delete $headers->{Status},    # code
@@ -57,8 +57,8 @@ sub perform_request {
                     $headers                      # headers
                 );
                 $deferred->resolve( $code, $response );
-            };
-            if ($@) {
+                1;
+            }) {
                 $deferred->reject($@);
             }
 

--- a/lib/Search/Elasticsearch/Cxn/AEHTTP.pm
+++ b/lib/Search/Elasticsearch/Cxn/AEHTTP.pm
@@ -2,7 +2,6 @@ package Search::Elasticsearch::Cxn::AEHTTP;
 
 use AnyEvent::HTTP qw(http_request);
 use Promises qw(deferred);
-use Try::Tiny;
 use Moo;
 
 with 'Search::Elasticsearch::Role::Cxn::Async';
@@ -49,7 +48,7 @@ sub perform_request {
         ( $self->is_https ? ( tls_ctx => $self->_tls_ctx ) : () ),
         sub {
             my ( $body, $headers ) = @_;
-            try {
+            eval {
                 my ( $code, $response ) = $self->process_response(
                     $params,                      # request
                     delete $headers->{Status},    # code
@@ -58,9 +57,9 @@ sub perform_request {
                     $headers                      # headers
                 );
                 $deferred->resolve( $code, $response );
-            }
-            catch {
-                $deferred->reject($_);
+            };
+            if ($@) {
+                $deferred->reject($@);
             }
 
         }

--- a/lib/Search/Elasticsearch/Cxn/Hijk.pm
+++ b/lib/Search/Elasticsearch/Cxn/Hijk.pm
@@ -53,11 +53,11 @@ sub perform_request {
         if %{$self->default_headers};
 
     my $response;
-    eval {
+    unless (eval {
         local $SIG{PIPE} = sub { die $! };
         $response = Hijk::request( \%args );
-    };
-    if ($@) {
+        1;
+    }) {
         $response = {
             status => 500,
             error  => $@ || 'Unknown error'

--- a/lib/Search/Elasticsearch/Cxn/Hijk.pm
+++ b/lib/Search/Elasticsearch/Cxn/Hijk.pm
@@ -4,7 +4,6 @@ use Moo;
 with 'Search::Elasticsearch::Role::Cxn', 'Search::Elasticsearch::Role::Is_Sync';
 
 use Hijk 0.27;
-use Try::Tiny;
 use namespace::clean;
 
 has 'connect_timeout' => ( is => 'ro', default => 2 );
@@ -54,16 +53,16 @@ sub perform_request {
         if %{$self->default_headers};
 
     my $response;
-    try {
+    eval {
         local $SIG{PIPE} = sub { die $! };
         $response = Hijk::request( \%args );
-    }
-    catch {
+    };
+    if ($@) {
         $response = {
             status => 500,
-            error  => $_ || 'Unknown error'
+            error  => $@ || 'Unknown error'
         };
-    };
+    }
 
     my $head = $response->{head} || {};
     my %head = map { lc($_) => $head->{$_} } keys %$head;

--- a/lib/Search/Elasticsearch/Cxn/Mojo.pm
+++ b/lib/Search/Elasticsearch/Cxn/Mojo.pm
@@ -2,7 +2,6 @@ package Search::Elasticsearch::Cxn::Mojo;
 
 use Mojo::UserAgent();
 use Promises qw(deferred);
-use Try::Tiny;
 use Moo;
 
 with 'Search::Elasticsearch::Role::Cxn::Async';
@@ -51,7 +50,7 @@ sub perform_request {
 
             my $headers = $res->headers->to_hash;
             $headers->{ lc($_) } = delete $headers->{$_} for keys %{$headers};
-            try {
+            eval {
                 my ( $code, $response ) = $self->process_response(
                     $params,    # request
                     ( $res->code || 500 ),    # status
@@ -60,10 +59,10 @@ sub perform_request {
                     $headers,                 # headers
                 );
                 $deferred->resolve( $code, $response );
-            }
-            catch {
-                $deferred->reject($_);
             };
+            if ($@) {
+                $deferred->reject($@);
+            }
         }
     );
     $deferred->promise;

--- a/lib/Search/Elasticsearch/Cxn/Mojo.pm
+++ b/lib/Search/Elasticsearch/Cxn/Mojo.pm
@@ -50,7 +50,7 @@ sub perform_request {
 
             my $headers = $res->headers->to_hash;
             $headers->{ lc($_) } = delete $headers->{$_} for keys %{$headers};
-            eval {
+            unless (eval {
                 my ( $code, $response ) = $self->process_response(
                     $params,    # request
                     ( $res->code || 500 ),    # status
@@ -59,8 +59,8 @@ sub perform_request {
                     $headers,                 # headers
                 );
                 $deferred->resolve( $code, $response );
-            };
-            if ($@) {
+                1;
+            }) {
                 $deferred->reject($@);
             }
         }

--- a/lib/Search/Elasticsearch/Cxn/NetCurl.pm
+++ b/lib/Search/Elasticsearch/Cxn/NetCurl.pm
@@ -93,12 +93,12 @@ sub perform_request {
 
     my ( $code, $msg, $headers );
 
-    eval {
+    unless (eval {
         $handle->perform;
         ( undef, undef, $code, $msg, $headers )
             = parse_http_response( $head, HEADERS_AS_HASHREF );
-    };
-    if ($@) {
+        1;
+    }) {
         $code = 509;
         $msg  = ( 0 + $@ ) . ": $@";
         $msg . ", " . $handle->error

--- a/lib/Search/Elasticsearch/Cxn/NetCurl.pm
+++ b/lib/Search/Elasticsearch/Cxn/NetCurl.pm
@@ -7,7 +7,6 @@ use Search::Elasticsearch 6.00;
 our $VERSION = "6.00";
 
 use HTTP::Parser::XS qw(HEADERS_AS_HASHREF parse_http_response);
-use Try::Tiny;
 use Net::Curl::Easy qw(
     CURLOPT_HEADER
     CURLOPT_VERBOSE
@@ -94,18 +93,18 @@ sub perform_request {
 
     my ( $code, $msg, $headers );
 
-    try {
+    eval {
         $handle->perform;
         ( undef, undef, $code, $msg, $headers )
             = parse_http_response( $head, HEADERS_AS_HASHREF );
-    }
-    catch {
+    };
+    if ($@) {
         $code = 509;
-        $msg  = ( 0 + $_ ) . ": $_";
+        $msg  = ( 0 + $@ ) . ": $@";
         $msg . ", " . $handle->error
             if $handle->error;
         undef $content;
-    };
+    }
 
     return $self->process_response(
         $params,     # request

--- a/lib/Search/Elasticsearch/CxnPool/Async/Static/NoPing.pm
+++ b/lib/Search/Elasticsearch/CxnPool/Async/Static/NoPing.pm
@@ -5,7 +5,6 @@ with 'Search::Elasticsearch::Role::CxnPool::Static::NoPing',
     'Search::Elasticsearch::Role::Is_Async';
 
 use Promises qw(deferred);
-use Try::Tiny;
 use namespace::clean;
 
 #===================================
@@ -14,16 +13,14 @@ around 'next_cxn' => sub {
     my ( $orig, $self ) = @_;
 
     my $deferred = deferred;
-    try {
+    eval {
         my $cxn = $orig->($self);
         $deferred->resolve($cxn);
-    }
-    catch {
-        $deferred->reject($_);
     };
-
+    if ($@) {
+        $deferred->reject($@);
+    }
     $deferred->promise;
-
 };
 
 1;

--- a/lib/Search/Elasticsearch/CxnPool/Async/Static/NoPing.pm
+++ b/lib/Search/Elasticsearch/CxnPool/Async/Static/NoPing.pm
@@ -13,11 +13,11 @@ around 'next_cxn' => sub {
     my ( $orig, $self ) = @_;
 
     my $deferred = deferred;
-    eval {
+    unless (eval {
         my $cxn = $orig->($self);
         $deferred->resolve($cxn);
-    };
-    if ($@) {
+        1;
+    }) {
         $deferred->reject($@);
     }
     $deferred->promise;

--- a/lib/Search/Elasticsearch/Role/Client/Direct.pm
+++ b/lib/Search/Elasticsearch/Role/Client/Direct.pm
@@ -16,7 +16,7 @@ sub parse_request {
     my $params = { ref $_[0] ? %{ shift() } : @_ };
 
     my $request;
-    eval {
+    unless (eval {
         $request = {
             ignore    => delete $params->{ignore} || [],
             method    => $defn->{method}          || 'GET',
@@ -25,8 +25,8 @@ sub parse_request {
             body => $self->_parse_body( $defn->{body}, $params ),
             qs   => $self->_parse_qs( $defn->{qs},     $params ),
         };
-    };
-    if ($@) {
+        1;
+    }) {
         my $error = $@;
         chomp $error;
         my $name = $defn->{name} || '<unknown method>';

--- a/lib/Search/Elasticsearch/Role/CxnPool/Sniff.pm
+++ b/lib/Search/Elasticsearch/Role/CxnPool/Sniff.pm
@@ -7,7 +7,6 @@ use namespace::clean;
 
 use Search::Elasticsearch::Util qw(parse_params);
 use List::Util qw(min);
-use Try::Tiny;
 
 has 'sniff_interval' => ( is => 'ro', default => 300 );
 has 'next_sniff'     => ( is => 'rw', default => 0 );

--- a/lib/Search/Elasticsearch/Role/Logger.pm
+++ b/lib/Search/Elasticsearch/Role/Logger.pm
@@ -3,7 +3,6 @@ package Search::Elasticsearch::Role::Logger;
 use Moo::Role;
 
 use URI();
-use Try::Tiny;
 use Search::Elasticsearch::Util qw(new_error);
 use namespace::clean;
 

--- a/lib/Search/Elasticsearch/Role/Serializer/JSON.pm
+++ b/lib/Search/Elasticsearch/Role/Serializer/JSON.pm
@@ -66,6 +66,7 @@ sub encode_pretty {
         $self->JSON->pretty(0);
         die "$@";
     }
+    $self->JSON->pretty(0);
 
     return $json;
 }

--- a/lib/Search/Elasticsearch/Role/Transport.pm
+++ b/lib/Search/Elasticsearch/Role/Transport.pm
@@ -4,7 +4,6 @@ use Moo::Role;
 
 requires qw(perform_request);
 
-use Try::Tiny;
 use Search::Elasticsearch::Util qw(parse_params is_compat);
 use namespace::clean;
 

--- a/lib/Search/Elasticsearch/Transport.pm
+++ b/lib/Search/Elasticsearch/Transport.pm
@@ -20,7 +20,7 @@ sub perform_request {
 
     my ( $code, $response, $cxn );
 
-    eval {
+    unless (eval {
         $cxn = $pool->next_cxn;
         my $start = time();
         $logger->trace_request( $cxn, $params );
@@ -28,9 +28,8 @@ sub perform_request {
         ( $code, $response ) = $cxn->perform_request($params);
         $pool->request_ok($cxn);
         $logger->trace_response( $cxn, $code, $response, time() - $start );
-    };
-
-    if ($@) {
+        1;
+    }) {
         my $error = upgrade_error(
             $@,
             {   request     => $params,

--- a/t/30_Logger/40_trace_request.t
+++ b/t/30_Logger/40_trace_request.t
@@ -27,7 +27,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'No body - format';
 # Request to: https://foo.bar:444/some/path
-curl -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1'
+curl -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true'
 REQUEST
 
 # Std body
@@ -47,7 +47,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'Body - format';
 # Request to: https://foo.bar:444/some/path
-curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1' -d '
+curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true' -d '
 {
    "foo" : "bar\n\u0027baz"
 }
@@ -71,7 +71,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'Bulk - format';
 # Request to: https://foo.bar:444/some/path
-curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1' -d '
+curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true' -d '
 {"foo":"bar\n\u0027baz"}
 {"foo":"bar\n\u0027baz"}
 '
@@ -93,7 +93,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'Body string - format';
 # Request to: https://foo.bar:444/some/path
-curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1' -d '
+curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true' -d '
 The quick brown fox
 jumped over the lazy dog\u0027s basket'
 REQUEST

--- a/t/30_Logger_Async/40_trace_request.t
+++ b/t/30_Logger_Async/40_trace_request.t
@@ -27,7 +27,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'No body - format';
 # Request to: https://foo.bar:444/some/path
-curl -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1'
+curl -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true'
 REQUEST
 
 # Std body
@@ -47,7 +47,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'Body - format';
 # Request to: https://foo.bar:444/some/path
-curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1' -d '
+curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true' -d '
 {
    "foo" : "bar\n\u0027baz"
 }
@@ -71,7 +71,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'Bulk - format';
 # Request to: https://foo.bar:444/some/path
-curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1' -d '
+curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true' -d '
 {"foo":"bar\n\u0027baz"}
 {"foo":"bar\n\u0027baz"}
 '
@@ -93,7 +93,7 @@ ok $l->trace_request(
 
 is $format, <<'REQUEST', 'Body string - format';
 # Request to: https://foo.bar:444/some/path
-curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=1' -d '
+curl -H "Content-type: application/json" -XPOST 'http://localhost:9200/xyz?foo=bar&pretty=true' -d '
 The quick brown fox
 jumped over the lazy dog\u0027s basket'
 REQUEST


### PR DESCRIPTION
Addressing issue: https://github.com/elastic/elasticsearch-perl/issues/162

Replacing Try::Tiny with raw eval as it has speed issues.
Also fixed a pretty=1 vs pretty=true issue in the test files.

Had some issues running the other dists, eventually worked around this via ```PERL5LIB=`pwd`/../lib ES=localhost:9200 dzil test``` and everything passed through there were some deprecation warnings.

I don't have any ES instance other than 6.5.4 at the moment so I can't test the 1 and 2 branches easily
