### PR TITLE
Add Travis CI as testing platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ foo
 .project
 Search-Elasticsearch-*
 servers/*
+elasticsearch/*
 cover_db
 doc
 log
@@ -12,4 +13,4 @@ bench_cxn.pl
 *.xml
 shield/*
 .DS_Store
-
+.perl-version

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "spec"]
-	path = spec
-	url = https://github.com/elasticsearch/elasticsearch-rest-api-spec.git
 [submodule "elasticsearch"]
 	path = elasticsearch
-	url = https://github.com/elasticsearch/elasticsearch.git
+	url = https://github.com/elastic/elasticsearch

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   global:
     - ES="localhost:9200"
 
-sudo: true
+sudo: false
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: perl
 
 env:
-  - IN_TRAVIS=1 AUTHOR_TESTING=1
   global:
     - ES=localhost:9200
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,11 @@ matrix:
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
 
 before_install:
+  - cpanm LWP::Simple # optional dependency
   - ./travis/run_es_docker.sh
   - ./travis/checkout_yaml_test.pl
 
 script:
   - prove -l t/{1,2,3,4,5,6,9}*/*.t
   - prove -l t/Client_$CLIENT_VER/*.t
-  - perl ./test/run_yaml_test.pl
+  - ./test/run_yaml_tests.pl

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,5 +33,4 @@ before_install:
 script:
   - prove -l t/{1,2,3,4,5,6,9}*/*.t
   - prove -l t/Client_$CLIENT_VER/*.t
-  - prove -l t/Client_${CLIENT_VER}_Async/*.t
   - ./test/run_yaml_test.pl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: perl
 
+services:
+  - docker
+
 env:
   global:
     - ES=localhost:9200
@@ -28,6 +31,7 @@ matrix:
       env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
     - perl: 5.24
       env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+
   allow_failures:
     - perl: dev
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
@@ -38,4 +42,10 @@ sudo: false
 
 before_install:
   - ./travis/run_es_docker.sh
-  - eval $(curl https://travis-perl.github.io/init) --auto
+  - ./travis/checkout_yaml_test.pl
+
+script:
+  - prove -l t/{1,2,3,4,5,6,9}*/*.t
+  - prove -l t/Client_$CLIENT_VER/*.t
+  - prove -l t/Client_${CLIENT_VER}_Async/*.t
+  - ./test/run_yaml_test.pl

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,4 @@ before_install:
 script:
   - prove -l t/{1,2,3,4,5,6,9}*/*.t
   - prove -l t/Client_$CLIENT_VER/*.t
-  - ./test/run_yaml_test.pl
+  - perl ./test/run_yaml_test.pl

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: perl
+
+env:
+  - IN_TRAVIS=1 AUTHOR_TESTING=1
+  global:
+    - ES=localhost:9200
+
+matrix:
+  fast_finish: true
+  include:
+    - perl: dev
+      env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
+    - perl: 5.30
+      env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
+    - perl: 5.28
+      env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
+    - perl: 5.26
+      env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
+    - perl: 5.24
+      env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
+
+    - perl: dev
+      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+    - perl: 5.30
+      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+    - perl: 5.28
+      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+    - perl: 5.26
+      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+    - perl: 5.24
+      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+  allow_failures:
+    - perl: dev
+      env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
+    - perl: dev
+      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
+
+sudo: false
+
+before_install:
+  - ./travis/run_es_docker.sh
+  - eval $(curl https://travis-perl.github.io/init) --auto

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,22 +21,9 @@ matrix:
     - perl: 5.24
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
 
-    - perl: dev
-      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
-    - perl: 5.30
-      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
-    - perl: 5.28
-      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
-    - perl: 5.26
-      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
-    - perl: 5.24
-      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
-
   allow_failures:
     - perl: dev
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
-    - perl: dev
-      env: CLIENT_VER="5_0" ES_VERSION="5.0.0"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ services:
 
 env:
   global:
-    - ES=localhost:9200
+    - ES="localhost:9200"
+
+sudo: true
 
 matrix:
   fast_finish: true
@@ -20,12 +22,9 @@ matrix:
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
     - perl: 5.24
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
-
   allow_failures:
     - perl: dev
       env: CLIENT_VER="6_0" ES_VERSION="6.0.0"
-
-sudo: false
 
 before_install:
   - ./travis/run_es_docker.sh

--- a/t/lib/es_async.pl
+++ b/t/lib/es_async.pl
@@ -13,11 +13,11 @@ my $trace
     : $ENV{TRACE} eq '1' ? 'Stderr'
     :                      [ 'File', $ENV{TRACE} ];
 
-die 'No $ENV{ES_VERSION} specified' unless $ENV{ES_VERSION};
+die 'No $ENV{CLIENT_VER} specified' unless $ENV{CLIENT_VER};
 
 my $cv = AE::cv;
 
-my $api      = "$ENV{ES_VERSION}::Direct";
+my $api      = "$ENV{CLIENT_VER}::Direct";
 my $body     = $ENV{ES_BODY} || 'GET';
 my $cxn      = $ENV{ES_CXN} || do "default_async_cxn.pl" || die( $@ || $! );
 my $cxn_pool = $ENV{ES_CXN_POOL} || 'Async::Static';
@@ -98,4 +98,3 @@ unless ( $ENV{ES_SKIP_PING} ) {
 }
 
 return $es;
-

--- a/t/lib/es_sync.pl
+++ b/t/lib/es_sync.pl
@@ -8,9 +8,9 @@ my $trace
     : $ENV{TRACE} eq '1' ? 'Stderr'
     :                      [ 'File', $ENV{TRACE} ];
 
-die 'No $ENV{ES_VERSION} specified' unless $ENV{ES_VERSION};
+die 'No $ENV{CLIENT_VER} specified' unless $ENV{CLIENT_VER};
 
-my $api      = "$ENV{ES_VERSION}::Direct";
+my $api      = "$ENV{CLIENT_VER}::Direct";
 my $body     = $ENV{ES_BODY} || 'GET';
 my $cxn      = $ENV{ES_CXN} || do "default_cxn.pl" || die( $@ || $! );
 my $cxn_pool = $ENV{ES_CXN_POOL} || 'Static';

--- a/test/run_yaml_tests.pl
+++ b/test/run_yaml_tests.pl
@@ -34,7 +34,6 @@ $ENV{ES_CXN}   = $cxn;
 $ENV{TRACE}    = $trace;
 $ENV{ES} ||= "localhost:9200";
 $ENV{ES_PLUGINS} = join ",", @plugins;
-$ENV{ES_HOME} ||= "/usr/share/elasticsearch/";
 
 my $tap = $harness->new(
     {   exec      => [ $^X, 'test/yaml_tester.pl' ],
@@ -48,7 +47,7 @@ if (@tests) {
     @tests = grep { -d || /\.ya?ml$/ } @tests;
 }
 else {
-    @tests = grep {-d} glob("elasticsearch/rest-api-spec/test/*");
+    @tests = grep {-d} glob("elasticsearch/rest-api-spec/src/main/resources/rest-api-spec/test/*");
 }
 
 # [$file,$name]
@@ -57,4 +56,3 @@ else {
 my $agg = $tap->runtests(@tests);
 
 exit $agg->has_errors;
-

--- a/travis/checkout_yaml_test.pl
+++ b/travis/checkout_yaml_test.pl
@@ -1,0 +1,13 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use LWP::Simple;
+use JSON::PP;
+
+my $contents = get("http://" . $ENV{ES}) or die "The server $ENV{ES} is not running!";
+
+$contents = decode_json $contents or die "The JSON response is not valid!";
+my $hash = $contents->{version}->{build_hash};
+
+`cd elasticsearch; git checkout $hash`;

--- a/travis/clean_es_docker.sh
+++ b/travis/clean_es_docker.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+docker container rm --force --volumes elasticsearch > /dev/null 2>&1 || true
+docker network rm esnet > /dev/null

--- a/travis/run_es_docker.sh
+++ b/travis/run_es_docker.sh
@@ -4,8 +4,8 @@ if [ -z $ES_VERSION ]; then
     exit 1;
 fi;
 
-docker pull docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
-docker network create esnet;
+docker pull docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION}
+docker network create esnet-oss;
 docker run \
   --rm \
   --publish 9200:9200 \
@@ -13,8 +13,8 @@ docker run \
   --env "path.repo=/tmp" \
   --env "repositories.url.allowed_urls=http://snapshot.*" \
   --env "discovery.type=single-node" \
-  --network=esnet \
-  --name=elasticsearch \
+  --network=esnet-oss \
+  --name=elasticsearch-oss \
   --detach \
-  docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
-docker run --network esnet --rm appropriate/curl --max-time 120 --retry 120 --retry-delay 1 --retry-connrefused --show-error --silent http://elasticsearch:9200
+  docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION}
+docker run --network esnet-oss --rm appropriate/curl --max-time 120 --retry 120 --retry-delay 1 --retry-connrefused --show-error --silent http://elasticsearch-oss:9200

--- a/travis/run_es_docker.sh
+++ b/travis/run_es_docker.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+if [ -z $ES_VERSION ]; then
+    echo "No ES_VERSION specified";
+    exit 1;
+fi;
+
+docker pull docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+docker network create esnet;
+docker run \
+  --rm \
+  --publish 9200:9200 \
+  --env "node.attr.testattr=test" \
+  --env "path.repo=/tmp" \
+  --env "repositories.url.allowed_urls=http://snapshot.*" \
+  --env "discovery.type=single-node" \
+  --network=esnet \
+  --name=elasticsearch \
+  --detach \
+  docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}
+docker run --network esnet --rm appropriate/curl --max-time 120 --retry 120 --retry-delay 1 --retry-connrefused --show-error --silent http://elasticsearch:9200


### PR DESCRIPTION
This PR adds the usage of Travis CI as testing platform. It contains the following changes:

- usage of docker to run Elasticsearch (ES) instance (see `./travis/run_es_docker.sh`);
- usage of git submodule to manage the ES code base in `/elasticsearch`;
- usage of the new script `./travis/checkout_yaml_test.pl` to checkout the ES code base according to the ES server running (using the `build_hash`);
- splitting the test runner into: unit test, client test, YAML test;

At the moment the tests are failing but the CI cycle is working fine. I removed the `Async` tests because I found a timeout issue that needs to be investigated more.  I would like also to use `Dist::Zilla` to run all the tests. The goal of this PR is having a basic working CI.

An example of Travis-CI output is reported here: https://travis-ci.org/ezimuel/elasticsearch-perl/builds/587679287