### PR TITLE
Fix for #169, adding include_type_name in indices.exists

### DIFF
--- a/lib/Search/Elasticsearch/Client/6_0/Role/API.pm
+++ b/lib/Search/Elasticsearch/Client/6_0/Role/API.pm
@@ -1932,6 +1932,7 @@ sub api {
             ignore_unavailable => "boolean",
             include_defaults   => "boolean",
             local              => "boolean",
+            include_type_name  => "boolean",
         },
     },
 


### PR DESCRIPTION
This PR includes the fix for #169, adding `include_type_name` in `indices.exists`