### PR TITLE
Add links to 5.0 and 6.0 back-compat clients

### DIFF
--- a/lib/Search/Elasticsearch.pm
+++ b/lib/Search/Elasticsearch.pm
@@ -160,6 +160,14 @@ install one of the following packages:
 
 =item *
 
+L<Search::Elasticsearch::Client::6_0>
+
+=item *
+
+L<Search::Elasticsearch::Client::5_0>
+
+=item *
+
 L<Search::Elasticsearch::Client::2_0>
 
 =item *


### PR DESCRIPTION
Hi!,

I've just added two missing links on the "PREVIOUS VERSIONS OF ELASTICSEARCH" to point to 5_0 and 6_0 clients.

