### PR TITLE
fix typo: retru_on_conflict => retry_on_conflict

### DIFF
--- a/lib/Search/Elasticsearch/Client/7_0/Role/API.pm
+++ b/lib/Search/Elasticsearch/Client/7_0/Role/API.pm
@@ -63,7 +63,7 @@ sub api {
             'lang'                   => 'lang',
             'require_alias'          => 'require_alias',
             'refresh'                => 'refresh',
-            'retry_on_conflict'      => 'retru_on_conflict',
+            'retry_on_conflict'      => 'retry_on_conflict',
             'wait_for_active_shards' => 'wait_for_active_shards',
             '_source'                => '_source',
             '_source_excludes'       => '_source_excludes',

--- a/lib/Search/Elasticsearch/Client/8_0/Role/API.pm
+++ b/lib/Search/Elasticsearch/Client/8_0/Role/API.pm
@@ -63,7 +63,7 @@ sub api {
             'lang'                   => 'lang',
             'require_alias'          => 'require_alias',
             'refresh'                => 'refresh',
-            'retry_on_conflict'      => 'retru_on_conflict',
+            'retry_on_conflict'      => 'retry_on_conflict',
             'wait_for_active_shards' => 'wait_for_active_shards',
             '_source'                => '_source',
             '_source_excludes'       => '_source_excludes',


### PR DESCRIPTION
This pull request modifies the typo `retru_on_conflict` in the Client::API. 
This modification allows the retry_on_conflict parameter to be used.