### PR TITLE
[DOCS] Adds EOL announcement to landing page

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -61,6 +61,9 @@
       </p>
       <p>
         The Perl client provides strongly typed requests and responses for all Elasticsearch APIs.
+        The end-of-life for version 8 of the elastic/elaticsearch-perl software has been announced. 
+        The announcement marks the final milestone of the lifecycle management phase of the 8.x 
+        release family. 8.x is the last major version supported by Elastic.
       </p>
       <p>
         <a href="https://www.elastic.co/guide/en/elasticsearch/client/perl-api/current/_features.html">

--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -61,9 +61,10 @@
       </p>
       <p>
         The Perl client provides strongly typed requests and responses for all Elasticsearch APIs.
-        The end-of-life for version 8 of the elastic/elaticsearch-perl software has been announced. 
+        <br>
+        <b>The end-of-life for version 8 of the elastic/elaticsearch-perl software has been announced. 
         The announcement marks the final milestone of the lifecycle management phase of the 8.x 
-        release family. 8.x is the last major version supported by Elastic.
+        release family. 8.x is the last major version supported by Elastic.</b>
       </p>
       <p>
         <a href="https://www.elastic.co/guide/en/elasticsearch/client/perl-api/current/_features.html">


### PR DESCRIPTION
## Overview

This PR adds the EOL announcement text to the landing page description.

### Preview

<img width="1044" alt="Screenshot 2023-06-06 at 16 44 27" src="https://github.com/elastic/elasticsearch-perl/assets/22324794/72281514-b5ef-46dc-a337-d201a57be92c">


