### PR TITLE
[DOCS] Fix `welcome-to-elastic` link

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -62,8 +62,8 @@
       <p>
         The Perl client provides strongly typed requests and responses for all Elasticsearch APIs.
         <br>
-        <b>The end-of-life for version 8 of the elastic/elaticsearch-perl software has been announced. 
-        The announcement marks the final milestone of the lifecycle management phase of the 8.x 
+        <b>The end-of-life for version 8 of the elastic/elaticsearch-perl software has been announced.
+        The announcement marks the final milestone of the lifecycle management phase of the 8.x
         release family. 8.x is the last major version supported by Elastic.</b>
       </p>
       <p>
@@ -117,7 +117,7 @@
       </a>
     </div>
     <div class="col-md-4 col-12 mb-2">
-      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+      <a class="no-text-decoration" href="https://www.elastic.co/guide/en/starting-with-the-elasticsearch-platform-and-its-solutions/current/getting-started-observability.html">
         <div class="card h-100">
           <h4 class="mt-3">
             <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>


### PR DESCRIPTION
**Problem:** In https://github.com/elastic/docs/pull/2752, we updated the URL prefix (`welcome-to-elastic`) and name for the "Welcome to Elastic Docs" docs. However, we still have some stray links that use the old `/welcome-to-elastic` URL prefix

**Solution:** Updates an outdated link.