### PR TITLE
Add the buildkite-pipeline to the catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,19 @@
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elasticsearch-perl
+spec:
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Elasticsearch Perl Client
+      name: elasticsearch-perl
+    spec:
+      repository: elastic/elasticsearch-perl
+      teams:
+        clients-team: {}
+        everyone:
+          access_level: READ_ONLY
+  owner: group:clients-team
+  type: buildkite-pipeline


### PR DESCRIPTION
Terrazzo currently uses the data defined in https://github.com/elastic/ci/blob/main/terrazzo/manifests/prod/buildkite/ to define the BK pipeline. Moving forward, teams should store this information in the affected repo so this PR converts the existing data into an RRE and stores it here.